### PR TITLE
feat: Collapse columns if viewport becomes narrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- When the viewport becomes narrow, collapse the table into 1-2 columns (#3)
+
 ## [0.1.0] - 2021-01-05
 
 ### Added

--- a/src/relay/display3/display3.css
+++ b/src/relay/display3/display3.css
@@ -55,6 +55,17 @@ summary.display3-shelf__title::-webkit-details-marker {
   padding: 0.5rem;
 }
 
+/*
+ If the frame becomes narrow, collapse the columns as needed.
+ Note: Use (3 + 1) instead of 3 since we have to account for borders and margins
+ of parent elements.
+ */
+@media (max-width: calc(12rem * (3 + 1))) {
+  .display3-shelf__items {
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  }
+}
+
 .display3-shelf__item {
   align-items: center;
   display: flex;


### PR DESCRIPTION
If the user makes the browser window or the main frame small, responsively reduce the number of columns to 2 or 1 instead of displaying a squished 3-column grid.

This addresses a feature request at https://kolmafia.us/threads/display3-a-three-column-display-case-ui.25813/post-161119