### PR TITLE
fix: Use <a> instead of <span> for item links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When the viewport becomes narrow, collapse the table into 1-2 columns (#3)
 - Use more distinguishable color for collapsed tables (#4)
 
+### Fixed
+
+- Use keyboard-accessible anchors for item names (#5)
+
 ## [0.1.0] - 2021-01-05
 
 ### Added

--- a/src/relay/display3/display3.css
+++ b/src/relay/display3/display3.css
@@ -82,8 +82,8 @@ summary.display3-shelf__title::-webkit-details-marker {
 }
 
 .display3-shelf__item-name {
-  cursor: pointer;
   font-weight: bold;
+  text-decoration: none;
 }
 
 .display3-shelf__item-count {

--- a/src/relay/displaycollection.tsx
+++ b/src/relay/displaycollection.tsx
@@ -38,11 +38,13 @@ function MultiColumnShelfTable(props: DisplayCaseShelf): JSX.Element {
                 />
               </div>
               <div class="display3-shelf__item-content">
-                <span
+                <a
                   class="display3-shelf__item-name"
-                  onclick={`descitem(${item.descid},${playerId})`}
+                  href={`desc_item.php?whichitem=${item.descid}&otherplayer=${playerId}`}
+                  target="_blank"
+                  onclick={`descitem(${item.descid},${playerId}); return false`}
                   dangerouslySetInnerHTML={{__html: displayCaseName}}
-                ></span>
+                ></a>
                 {amount !== 1 && (
                   <span class="display3-shelf__item-count">({amount})</span>
                 )}


### PR DESCRIPTION
This makes the item links keyboard-accessible.

- Since we use onclick to create popups (just like native KoL), the `href` attribute is non-functional. It merely exists to make browsers assign a "link" ARIA role to the <a> tag.
- Use `return false` to suppress the default behavior for <a> tags (navigating to the item page)
- Since <a> tags use `cursor: pointer` by default, no need to explicitly specify this.