### PR TITLE
fix: Use CSS Flexbox instead of Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use CSS Flexbox instead of Grid to correctly render shelves with >1000 rows
+  (#7)
+
 ## [0.1.1] - 2021-01-28
 
 ### Changed

--- a/src/relay/display3/display3.css
+++ b/src/relay/display3/display3.css
@@ -1,3 +1,7 @@
+:root {
+  --display3-shelf-gap: 0.5rem;
+}
+
 .display3-shelf {
   border: 1px solid blue;
   border-radius: 5px;
@@ -49,29 +53,34 @@ summary.display3-shelf__title::-webkit-details-marker {
 }
 
 .display3-shelf__items {
-  display: grid;
-  grid-gap: 0.5rem;
-  grid-template-columns: repeat(3, 1fr);
-  padding: 0.5rem;
-}
-
-/*
- If the frame becomes narrow, collapse the columns as needed.
- Note: Use (3 + 1) instead of 3 since we have to account for borders and margins
- of parent elements.
- */
-@media (max-width: calc(12rem * (3 + 1))) {
-  .display3-shelf__items {
-    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-  }
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 var(--display3-shelf-gap) var(--display3-shelf-gap) 0;
 }
 
 .display3-shelf__item {
   align-items: center;
   display: flex;
+  margin: var(--display3-shelf-gap) 0 0 var(--display3-shelf-gap);
+  width: calc(33.3% - var(--display3-shelf-gap));
   /* Prevent long item names from being center-aligned when squished into
      multiple lines*/
   text-align: initial;
+}
+
+/*
+ If the frame becomes narrow, collapse the columns as needed.
+ */
+@media (min-width: 30rem) and (max-width: 50rem) {
+  .display3-shelf__item {
+    width: calc(50% - var(--display3-shelf-gap));
+  }
+}
+
+@media (max-width: 30rem) {
+  .display3-shelf__item {
+    width: calc(100% - var(--display3-shelf-gap));
+  }
 }
 
 .display3-shelf__item-icon {


### PR DESCRIPTION
In Google Chrome, CSS grids with >1000 rows do not render correctly. [This is an intentional limit.](https://bugs.chromium.org/p/chromium/issues/detail?id=688640). For more information, see #6.

As a workaround, use CSS Flexbox instead of Grid. Use media queries to maintain a responsive layout that auto-collapses when the viewport becomes narrow.

Closes #6