### PR TITLE
fix: Suppress KoLmafia warning for multiple item name matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use CSS Flexbox instead of Grid to correctly render shelves with >1000 rows
   (#7)
+- Don't print warnings to the gCLI if there are multiple exact matches for the
+  item name. (#8)
 
 ## [0.1.1] - 2021-01-28
 


### PR DESCRIPTION
When `toItem()` encounters a string that could be matched to multiple items, it prints a warning to the gCLI. Since this isn't pretty, manually detect duplicate item names and dedupe them using the `descid`.

This addresses an issue described here: https://kolmafia.us/threads/display3-a-three-column-display-case-ui.25813/post-161119

Note that this does not handle a case where an _inexact_ item name matches multiple items. This shouldn't happen in practice, though, since we are parsing item names directly from `displaycollection.php`.