### PR TITLE
fix: Don't parse a Display Case message containing <font>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (#7)
 - Don't print warnings to the gCLI if there are multiple exact matches for the
   item name. (#8)
+- Fix a bug that caused a Display Case message containing an external link to be
+  incorrectly parsed as a shelf. (#9)
 
 ## [0.1.1] - 2021-01-28
 

--- a/spec/lib/parse-displaycollection.spec.ts
+++ b/spec/lib/parse-displaycollection.spec.ts
@@ -85,13 +85,20 @@ const shelf4Table =
   '</table></span></td></tr></table></center></td></tr><tr><td height=4></td></tr></table>';
 
 /**
- * Test input HTML
- *
- * - Player name replaced with "Player Name"
- * - Player ID replaced with 1234567890
+ * Generates test input HTML
+ * @param displayCaseMessage HTML for the user-supplied display case message
+ * @param shelfTable HTML snippet for each shelf <table></table>
  */
-const html =
-  `<html><head>
+function generateInputHtml(
+  displayCaseMessage: string,
+  shelfTables: string
+): string {
+  // Notes about the input HTML:
+  //
+  // - Player name replaced with "Player Name"
+  // - Player ID replaced with 1234567890
+  return (
+    `<html><head>
 <script language=Javascript>
 <!--
 if (parent.frames.length == -1) location.href="game.php";
@@ -114,18 +121,22 @@ var notchat = true;//-->
 <script language="Javascript" src="/basics.js"></script><link rel="stylesheet" href="/basics.1.css" /></head>
 
 <body>
-<div id='menu' class=rcm></div><centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Display Case (<a style='color: white; text-decoration: none;' href="showplayer.php?who=1234567890">Player Name</a>)</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><table><tr><td valign=center><img src="https://s3.amazonaws.com/images.kingdomofloathing.com/otherimages/museum/displaycase.gif" width=100 height=100></td><td valign=center>Collecting Rubber WWBD? bracelets(ID #1992).</td></tr></table><p><center>` +
-  shelf0Table +
-  shelf1Table +
-  shelf2Table +
-  shelf3Table +
-  shelf4Table +
-  `</center><p><center><a href="managecollection.php">Manage your Display Case</a></center><p><center><a href="museum.php?place=collections">Back to The Museum</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body><script src="/onfocus.1.js"></script></html>
-`;
+<div id='menu' class=rcm></div><centeR><table  width=95%  cellspacing=0 cellpadding=0><tr><td style="color: white;" align=center bgcolor=blue><b>Display Case (<a style='color: white; text-decoration: none;' href="showplayer.php?who=1234567890">Player Name</a>)</b></td></tr><tr><td style="padding: 5px; border: 1px solid blue;"><center><table><tr><td><table><tr><td valign=center><img src="https://s3.amazonaws.com/images.kingdomofloathing.com/otherimages/museum/displaycase.gif" width=100 height=100></td><td valign=center>` +
+    displayCaseMessage +
+    '</td></tr></table><p><center>' +
+    shelfTables +
+    '</center><p><center><a href="managecollection.php">Manage your Display Case</a></center><p><center><a href="museum.php?place=collections">Back to The Museum</a></center></td></tr></table></center></td></tr><tr><td height=4></td></tr></table></center></body><script src="/onfocus.1.js"></script></html>'
+  );
+}
 
 describe('displaycollection', () => {
   it('parseShelves()', () => {
-    const shelves = parseShelves(html);
+    const shelves = parseShelves(
+      generateInputHtml(
+        'This is the display case message',
+        shelf0Table + shelf1Table + shelf2Table + shelf3Table + shelf4Table
+      )
+    );
 
     const expectedShelves = [
       {

--- a/spec/lib/parse-displaycollection.spec.ts
+++ b/spec/lib/parse-displaycollection.spec.ts
@@ -130,202 +130,259 @@ var notchat = true;//-->
 }
 
 describe('displaycollection', () => {
-  it('parseShelves()', () => {
-    const shelves = parseShelves(
-      generateInputHtml(
-        'This is the display case message',
-        shelf0Table + shelf1Table + shelf2Table + shelf3Table + shelf4Table
-      )
-    );
+  describe('parseShelves()', () => {
+    it('should parse shelves correctly', () => {
+      const shelves = parseShelves(
+        generateInputHtml(
+          'This is the display case message',
+          shelf0Table + shelf1Table + shelf2Table + shelf3Table + shelf4Table
+        )
+      );
 
-    const expectedShelves = [
-      {
-        name: 'Display Case',
-        playerId: '1234567890',
-        items: new Map([
-          [
-            Item.get('Book of Old-Timey Carols'),
-            {amount: 1, displayCaseName: 'Book of Old-Timey Carols'},
-          ],
-          [
-            Item.get('Crimbo smile'),
-            {amount: 1, displayCaseName: 'Crimbo smile'},
-          ],
-          [
-            Item.get('deck of tropical cards'),
-            {amount: 1, displayCaseName: 'deck of tropical cards'},
-          ],
-          [
-            Item.get('easter egg balloon'),
-            {amount: 1, displayCaseName: 'easter egg balloon'},
-          ],
-          [
-            Item.get('lewd playing card'),
-            {amount: 3, displayCaseName: 'lewd playing card'},
-          ],
-          [
-            Item.get('mummy costume'),
-            {amount: 1, displayCaseName: 'mummy costume'},
-          ],
-          [
-            Item.get('oyster egg balloon'),
-            {amount: 1, displayCaseName: 'oyster egg balloon'},
-          ],
-        ]),
-      },
-      {
-        name: 'Items with nonstandard names',
-        playerId: '1234567890',
-        items: new Map([
-          [
-            Item.get('Love Potion #0'),
-            {amount: 1, displayCaseName: 'Love Potion #XYZ'},
-          ],
-          [
-            Item.get('spandex anniversary shorts'),
-            {amount: 1, displayCaseName: 'spandex anniversary shorts'},
-          ],
-        ]),
-      },
-      {
-        name: 'Unexpected Gifts',
-        playerId: '1234567890',
-        items: new Map([
-          [
-            Item.get('box of sunshine'),
-            {amount: 4, displayCaseName: 'box of sunshine'},
-          ],
-        ]),
-      },
-      {
-        name: "Dungeoneer's Dump",
-        playerId: '1234567890',
-        items: new Map([
-          [
-            Item.get("Frosty's iceball"),
-            {amount: 1, displayCaseName: "Frosty's iceball"},
-          ],
-          [
-            Item.get("Hodgman's varcolac paw"),
-            {amount: 1, displayCaseName: "Hodgman's varcolac paw"},
-          ],
-          [
-            Item.get("Ol' Scratch's ash can"),
-            {amount: 1, displayCaseName: "Ol' Scratch's ash can"},
-          ],
-          [
-            Item.get("Oscus's garbage can lid"),
-            {amount: 1, displayCaseName: "Oscus's garbage can lid"},
-          ],
-          [
-            Item.get("Zombo's empty eye"),
-            {amount: 1, displayCaseName: "Zombo's empty eye"},
-          ],
-          [
-            Item.get("Zombo's grievous greaves"),
-            {amount: 1, displayCaseName: "Zombo's grievous greaves"},
-          ],
-        ]),
-      },
-      {
-        name: 'Skillbooks',
-        playerId: '1234567890',
-        items: new Map([
-          [
-            Item.get("A Beginner's Guide to Charming Snakes"),
-            {
-              amount: 1,
-              displayCaseName: "A Beginner's Guide to Charming Snakes",
-            },
-          ],
-          [
-            Item.get('Asleep in the Cemetery'),
-            {amount: 1, displayCaseName: 'Asleep in the Cemetery'},
-          ],
-          [
-            Item.get("Benetton's Medley of Diversity"),
-            {amount: 1, displayCaseName: "Benetton's Medley of Diversity"},
-          ],
-          [
-            Item.get("Biddy Cracker's Old-Fashioned Cookbook"),
-            {
-              amount: 1,
-              displayCaseName: "Biddy Cracker's Old-Fashioned Cookbook",
-            },
-          ],
-          [
-            Item.get('Blizzards I Have Died In'),
-            {amount: 1, displayCaseName: 'Blizzards I Have Died In'},
-          ],
-          [
-            Item.get('Crimbo Candy Cookbook'),
-            {amount: 1, displayCaseName: 'Crimbo Candy Cookbook'},
-          ],
-          [
-            Item.get("Ellsbury's journal (used)"),
-            {amount: 1, displayCaseName: "Ellsbury's journal (used)"},
-          ],
-          [
-            Item.get("Elron's Explosive Etude"),
-            {amount: 1, displayCaseName: "Elron's Explosive Etude"},
-          ],
-          [
-            Item.get("Inigo's Incantation of Inspiration"),
-            {amount: 1, displayCaseName: "Inigo's Incantation of Inspiration"},
-          ],
-          [
-            Item.get("Kissin' Cousins"),
-            {amount: 1, displayCaseName: "Kissin' Cousins"},
-          ],
-          [Item.get('Let Me Be!'), {amount: 1, displayCaseName: 'Let Me Be!'}],
-          [
-            Item.get('Maxing, Relaxing'),
-            {amount: 1, displayCaseName: 'Maxing, Relaxing'},
-          ],
-          [
-            Item.get('Prelude of Precision'),
-            {amount: 1, displayCaseName: 'Prelude of Precision'},
-          ],
-          [
-            Item.get('Sensual Massage for Creeps'),
-            {amount: 1, displayCaseName: 'Sensual Massage for Creeps'},
-          ],
-          [
-            Item.get("Spellbook: Drescher's Annoying Noise"),
-            {
-              amount: 1,
-              displayCaseName: "Spellbook: Drescher's Annoying Noise",
-            },
-          ],
-          [
-            Item.get('Summer Nights'),
-            {amount: 1, displayCaseName: 'Summer Nights'},
-          ],
-          [
-            Item.get('Tales from the Fireside'),
-            {amount: 1, displayCaseName: 'Tales from the Fireside'},
-          ],
-          [
-            Item.get('The Art of Slapfighting'),
-            {amount: 1, displayCaseName: 'The Art of Slapfighting'},
-          ],
-          [
-            Item.get('Travels with Jerry'),
-            {amount: 1, displayCaseName: 'Travels with Jerry'},
-          ],
-          [
-            Item.get('Uncle Romulus'),
-            {amount: 1, displayCaseName: 'Uncle Romulus'},
-          ],
-          [
-            Item.get('Zu Mannkäse Dienen'),
-            {amount: 1, displayCaseName: 'Zu Mannkäse Dienen'},
-          ],
-        ]),
-      },
-    ];
+      const expectedShelves = [
+        {
+          name: 'Display Case',
+          playerId: '1234567890',
+          items: new Map([
+            [
+              Item.get('Book of Old-Timey Carols'),
+              {amount: 1, displayCaseName: 'Book of Old-Timey Carols'},
+            ],
+            [
+              Item.get('Crimbo smile'),
+              {amount: 1, displayCaseName: 'Crimbo smile'},
+            ],
+            [
+              Item.get('deck of tropical cards'),
+              {amount: 1, displayCaseName: 'deck of tropical cards'},
+            ],
+            [
+              Item.get('easter egg balloon'),
+              {amount: 1, displayCaseName: 'easter egg balloon'},
+            ],
+            [
+              Item.get('lewd playing card'),
+              {amount: 3, displayCaseName: 'lewd playing card'},
+            ],
+            [
+              Item.get('mummy costume'),
+              {amount: 1, displayCaseName: 'mummy costume'},
+            ],
+            [
+              Item.get('oyster egg balloon'),
+              {amount: 1, displayCaseName: 'oyster egg balloon'},
+            ],
+          ]),
+        },
+        {
+          name: 'Items with nonstandard names',
+          playerId: '1234567890',
+          items: new Map([
+            [
+              Item.get('Love Potion #0'),
+              {amount: 1, displayCaseName: 'Love Potion #XYZ'},
+            ],
+            [
+              Item.get('spandex anniversary shorts'),
+              {amount: 1, displayCaseName: 'spandex anniversary shorts'},
+            ],
+          ]),
+        },
+        {
+          name: 'Unexpected Gifts',
+          playerId: '1234567890',
+          items: new Map([
+            [
+              Item.get('box of sunshine'),
+              {amount: 4, displayCaseName: 'box of sunshine'},
+            ],
+          ]),
+        },
+        {
+          name: "Dungeoneer's Dump",
+          playerId: '1234567890',
+          items: new Map([
+            [
+              Item.get("Frosty's iceball"),
+              {amount: 1, displayCaseName: "Frosty's iceball"},
+            ],
+            [
+              Item.get("Hodgman's varcolac paw"),
+              {amount: 1, displayCaseName: "Hodgman's varcolac paw"},
+            ],
+            [
+              Item.get("Ol' Scratch's ash can"),
+              {amount: 1, displayCaseName: "Ol' Scratch's ash can"},
+            ],
+            [
+              Item.get("Oscus's garbage can lid"),
+              {amount: 1, displayCaseName: "Oscus's garbage can lid"},
+            ],
+            [
+              Item.get("Zombo's empty eye"),
+              {amount: 1, displayCaseName: "Zombo's empty eye"},
+            ],
+            [
+              Item.get("Zombo's grievous greaves"),
+              {amount: 1, displayCaseName: "Zombo's grievous greaves"},
+            ],
+          ]),
+        },
+        {
+          name: 'Skillbooks',
+          playerId: '1234567890',
+          items: new Map([
+            [
+              Item.get("A Beginner's Guide to Charming Snakes"),
+              {
+                amount: 1,
+                displayCaseName: "A Beginner's Guide to Charming Snakes",
+              },
+            ],
+            [
+              Item.get('Asleep in the Cemetery'),
+              {amount: 1, displayCaseName: 'Asleep in the Cemetery'},
+            ],
+            [
+              Item.get("Benetton's Medley of Diversity"),
+              {amount: 1, displayCaseName: "Benetton's Medley of Diversity"},
+            ],
+            [
+              Item.get("Biddy Cracker's Old-Fashioned Cookbook"),
+              {
+                amount: 1,
+                displayCaseName: "Biddy Cracker's Old-Fashioned Cookbook",
+              },
+            ],
+            [
+              Item.get('Blizzards I Have Died In'),
+              {amount: 1, displayCaseName: 'Blizzards I Have Died In'},
+            ],
+            [
+              Item.get('Crimbo Candy Cookbook'),
+              {amount: 1, displayCaseName: 'Crimbo Candy Cookbook'},
+            ],
+            [
+              Item.get("Ellsbury's journal (used)"),
+              {amount: 1, displayCaseName: "Ellsbury's journal (used)"},
+            ],
+            [
+              Item.get("Elron's Explosive Etude"),
+              {amount: 1, displayCaseName: "Elron's Explosive Etude"},
+            ],
+            [
+              Item.get("Inigo's Incantation of Inspiration"),
+              {
+                amount: 1,
+                displayCaseName: "Inigo's Incantation of Inspiration",
+              },
+            ],
+            [
+              Item.get("Kissin' Cousins"),
+              {amount: 1, displayCaseName: "Kissin' Cousins"},
+            ],
+            [
+              Item.get('Let Me Be!'),
+              {amount: 1, displayCaseName: 'Let Me Be!'},
+            ],
+            [
+              Item.get('Maxing, Relaxing'),
+              {amount: 1, displayCaseName: 'Maxing, Relaxing'},
+            ],
+            [
+              Item.get('Prelude of Precision'),
+              {amount: 1, displayCaseName: 'Prelude of Precision'},
+            ],
+            [
+              Item.get('Sensual Massage for Creeps'),
+              {amount: 1, displayCaseName: 'Sensual Massage for Creeps'},
+            ],
+            [
+              Item.get("Spellbook: Drescher's Annoying Noise"),
+              {
+                amount: 1,
+                displayCaseName: "Spellbook: Drescher's Annoying Noise",
+              },
+            ],
+            [
+              Item.get('Summer Nights'),
+              {amount: 1, displayCaseName: 'Summer Nights'},
+            ],
+            [
+              Item.get('Tales from the Fireside'),
+              {amount: 1, displayCaseName: 'Tales from the Fireside'},
+            ],
+            [
+              Item.get('The Art of Slapfighting'),
+              {amount: 1, displayCaseName: 'The Art of Slapfighting'},
+            ],
+            [
+              Item.get('Travels with Jerry'),
+              {amount: 1, displayCaseName: 'Travels with Jerry'},
+            ],
+            [
+              Item.get('Uncle Romulus'),
+              {amount: 1, displayCaseName: 'Uncle Romulus'},
+            ],
+            [
+              Item.get('Zu Mannkäse Dienen'),
+              {amount: 1, displayCaseName: 'Zu Mannkäse Dienen'},
+            ],
+          ]),
+        },
+      ];
 
-    expect(shelves).toHaveSize(expectedShelves.length);
-    expect(shelves).toEqual(expectedShelves);
+      expect(shelves).toHaveSize(expectedShelves.length);
+      expect(shelves).toEqual(expectedShelves);
+    });
+
+    it('should correctly handle display case messages with links', () => {
+      const shelves = parseShelves(
+        generateInputHtml(
+          'Display case message with links<br><br>A link on next line<br>www.google.com<br><a target=_blank href="http://www.example.com/"><font color=blue>[link]</font></a> http:// www.example.com/<br>more links: <a target=_blank href="https://www.kingdomofloathing.com/"><font color=blue>[link]</font></a> https:// www.kingdomofloathin g.com/<br>end of links',
+          shelf0Table
+        )
+      );
+
+      const expectedShelves = [
+        {
+          name: 'Display Case',
+          playerId: '1234567890',
+          items: new Map([
+            [
+              Item.get('Book of Old-Timey Carols'),
+              {amount: 1, displayCaseName: 'Book of Old-Timey Carols'},
+            ],
+            [
+              Item.get('Crimbo smile'),
+              {amount: 1, displayCaseName: 'Crimbo smile'},
+            ],
+            [
+              Item.get('deck of tropical cards'),
+              {amount: 1, displayCaseName: 'deck of tropical cards'},
+            ],
+            [
+              Item.get('easter egg balloon'),
+              {amount: 1, displayCaseName: 'easter egg balloon'},
+            ],
+            [
+              Item.get('lewd playing card'),
+              {amount: 3, displayCaseName: 'lewd playing card'},
+            ],
+            [
+              Item.get('mummy costume'),
+              {amount: 1, displayCaseName: 'mummy costume'},
+            ],
+            [
+              Item.get('oyster egg balloon'),
+              {amount: 1, displayCaseName: 'oyster egg balloon'},
+            ],
+          ]),
+        },
+      ];
+
+      expect(shelves).toHaveSize(expectedShelves.length);
+      expect(shelves).toEqual(expectedShelves);
+    });
   });
 });

--- a/src/lib/parse-displaycollection.ts
+++ b/src/lib/parse-displaycollection.ts
@@ -136,13 +136,15 @@ function parseShelfRow(
   return [item, itemCount, itemName, playerId];
 }
 
+const XPATH_SHELF_SELECTOR = '//table//table//table[.//table//span[@id]]';
+
 /**
  * Parse `displaycollection.php` and extract shelf information.
  * @param html HTML source of `displaycollection.php`
  * @return Array of shelves
  */
 export function parseShelves(html: string): DisplayCaseShelf[] {
-  return xpath(html, '//table//table//table[.//font]').map(table => {
+  return xpath(html, XPATH_SHELF_SELECTOR).map(table => {
     const name = xpath(table, '//font/text()')[0];
     let _playerId = '';
 


### PR DESCRIPTION
Previously, our XPath tag parsed any `<table>` containing a `<font>` as a shelf. This strategy failed when the Display Case message contained a `<font>` tag--which happened when the user put a URL (e.g. `http://www.example.com/`) in the DC message. This caused the script to incorrectly parse it as an empty shelf with the name "[link]".

To fix this, change the XPath selector to search for a `<table>` containing another `<table>` which contains a `<span id=...>`. Also add a test case to check this.