### PR TITLE
Use `descToItem()` to retrieve item from descid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Performance improvements ([#11])
+
+[#11]: https://github.com/Loathing-Associates-Scripting-Society/display3/pull/11
+
 ## [0.1.2] - 2021-01-29
 
 ### Fixed

--- a/spec/lib/item.ts
+++ b/spec/lib/item.ts
@@ -312,3 +312,18 @@ allowInstantiateItem = false;
 const ITEMS_BY_NAME = new Map<string, Item>(
   ALL_ITEMS.map(item => [item.name.toLowerCase(), item])
 );
+
+/**
+ * Item lookup table by descid
+ */
+const ITEMS_BY_DESCID = new Map<string, Item>(
+  ALL_ITEMS.map(item => [item.descid, item])
+);
+
+/**
+ * Facsimilie implementation of KoLmafia's `descToItem()`.
+ * @param descid
+ */
+export function descToItem(descid: string): Item {
+  return ITEMS_BY_DESCID.get(descid) ?? ITEM_NONE;
+}

--- a/spec/lib/parse-displaycollection.spec.ts
+++ b/spec/lib/parse-displaycollection.spec.ts
@@ -1,11 +1,12 @@
 import mock from 'mock-require';
 import {xpath} from 'kolmafia-stubs';
 
-import {Item, ITEM_NONE, JavaException} from './item';
+import {descToItem, Item, ITEM_NONE, JavaException} from './item';
 
 //-------- Inject mock objects and methods
 
 mock('kolmafia', {
+  descToItem,
   getRevision: () => 20590,
   print(str: string): void {
     console.log(str);


### PR DESCRIPTION
Use KoLmafia's `descToItem()` library function instead of our own hacky `findItemByDescid()`.

Also add a stub for `descToItem()` so that our tests still run.

Quick testing reveals that this results in a small speed increase, when tested on HolderOfSecrets' massive display case:

- Before: 12055ms, 14404ms, 15835ms, 11921ms, 11453ms (avg: 13133.6ms)
- After: 13546ms, 10575ms, 12719ms, 10514ms, 10209ms, 11008ms (avg: 11428.5ms)
- Speed increase: ~15% (time reduction ~13%)