### PR TITLE
ci: Drop Node.js v10, add v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['10', '12', '14']
+        node-version: ['12', '14', '16']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js v10 reached EOL on 2021-04-30, v16 was released on 2021-04-20.

Closes #1 