### PR TITLE
build: Use ts-node

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,13 @@ To develop Display3, we recommend the following setup:
 
 `package.json` contains several useful NPM scripts for development.
 
-- `npm run compile`: Compiles all TypeScript code to JavaScript, placing them in the `/build/` directory.
-- `npm test`: Compiles all TypeScript code, executes all tests, and checks code style.
-- `npm run bundle`: Creates bundled files under `/build/dist/`, which can be executed by KoLmafia
-- `npm run release`: Runs `npm run bundle`, then commits the bundled files to the `release` branch. This uses an existing tag's annotation as the commit message.
-  - For example, `npm run release -- --use-tag-message=v0.1.2` will take the annotation from the tag named `v0.1.2` and use it as the commit message.
-- `npm run clean`: Removes all compiled/generated files.
+- `npm run test`: Executes all tests and checks code style.
+- `npm run lint`: Checks code style.
+- `npm run build`: Creates bundled files under `build/`, which can be executed
+  by KoLmafia.
+- `npm run release`: Runs `npm run build`, then commits the bundled files to the
+  `release` branch. This uses an existing tag's annotation as the commit
+  message.
+  - For example, `npm run release -- --use-tag-message=v0.1.2` will take the
+    annotation from the gittag named `v0.1.2` and use it as the commit message.
+- `npm run clean`: Removes all bundled files.

--- a/node-scripts/release-to-branch.ts
+++ b/node-scripts/release-to-branch.ts
@@ -10,7 +10,7 @@ import simpleGit, {GitError} from 'simple-git';
  * Temporary directory used to store build artifacts and dependencies.
  * This must be .gitignore-ed!
  */
-const DIST_DIR = 'build/dist';
+const DIST_DIR = 'build';
 /**
  * .gitignore file to filter out everything that does not belong in the release
  * branch.

--- a/node-scripts/tsconfig.json
+++ b/node-scripts/tsconfig.json
@@ -1,4 +1,0 @@
-// Configuration for Node.js scripts
-{
-  "extends": "../tsconfig.base.json"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -535,6 +535,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -919,6 +925,12 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1019,6 +1031,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "dir-glob": {
@@ -2141,6 +2159,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "map-obj": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.0.tgz",
@@ -3146,6 +3170,20 @@
       "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
       "dev": true
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3370,6 +3408,12 @@
       "version": "20.2.7",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
       "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Display Case relay override script for KoLmafia",
   "private": true,
   "scripts": {
-    "bundle": "rollup -c",
+    "build": "rollup -c",
     "clean": "gts clean",
     "fix": "gts fix",
     "lint": "gts lint",
-    "prerelease": "npm run clean && npm run bundle",
+    "prerelease": "npm run clean && npm run build",
     "release": "ts-node ./node-scripts/release-to-branch.ts",
     "test": "jasmine --require=ts-node/register",
     "posttest": "npm run lint"

--- a/package.json
+++ b/package.json
@@ -6,14 +6,11 @@
   "scripts": {
     "bundle": "rollup -c",
     "clean": "gts clean",
-    "compile": "tsc -b",
     "fix": "gts fix",
     "lint": "gts lint",
-    "prepare": "npm run compile",
-    "prerelease": "npm run clean && npm run compile && npm run bundle",
-    "release": "node --require=source-map-support/register ./build/node-scripts/release-to-branch.js",
-    "pretest": "npm run compile",
-    "test": "jasmine --require=source-map-support/register",
+    "prerelease": "npm run clean && npm run bundle",
+    "release": "ts-node ./node-scripts/release-to-branch.ts",
+    "test": "jasmine --require=ts-node/register",
     "posttest": "npm run lint"
   },
   "repository": {
@@ -50,7 +47,7 @@
     "rollup": "^2.41.2",
     "rollup-plugin-copy": "^3.4.0",
     "simple-git": "^2.36.2",
-    "source-map-support": "^0.5.19",
+    "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import createBubleConfig from 'buble-config-rhino';
 import buble from '@rollup/plugin-buble';
 import pkg from './package.json';
 
-const OUTPUT_DIR = 'build/dist';
+const OUTPUT_DIR = 'build';
 const OUTPUT_DIR_RELAY = `${OUTPUT_DIR}/relay`;
 
 /** @type {import('rollup').RollupOptions} */

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,6 +1,6 @@
 {
-  "spec_dir": "build/spec",
-  "spec_files": ["**/*[sS]pec.js"],
+  "spec_dir": "spec",
+  "spec_files": ["**/*[sS]pec.ts"],
   "helpers": ["helpers/**/*.js"],
   "stopSpecOnExpectationFailure": false,
   "random": true

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -1,5 +1,0 @@
-// Configuration for tests
-{
-  "extends": "../tsconfig.base.json",
-  "references": [{"path": "../src"}]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
-// "Solution" tsconfig for compiling all TS files
+// "Solution" tsconfig for code that runs in Node.js (testing, scripts)
 // Also used for type checking within VS Code
 {
   "extends": "./tsconfig.base.json",
-  "compilerOptions": {"outDir": "build"},
-  "files": [],
-  "references": [{"path": "node-scripts"}, {"path": "spec"}, {"path": "src"}]
+  // KoLmafia code uses separate tsconfig
+  "exclude": ["src"]
 }


### PR DESCRIPTION
Use [ts-node](https://github.com/TypeStrong/ts-node) to run tests and release scripts directly instead of having a separate compile step. This allows us to iterate faster during development. Also, not having those extra files pollute `build/` means that we can use that directory exclusively for bundled files (Rollup output, CSS).

Sadly, [we can't convert the Rollup config to TypeScript and run it using ts-node](https://stackoverflow.com/questions/54711437). Not without creating a "bootstrap" script, which feels icky to me.

Incidentally, this also renames the `bundle` NPM script to the more familiar `build`.